### PR TITLE
add scheduler and image runtime

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,3 +6,15 @@ store:
   sqlite_path: ./data/app.db
   log_root: ./data/logs
   artifact_root: ./data/artifacts
+
+image:
+  allowed_sources:
+    - local
+    - remote
+  default_source: local
+  pull_policy: if_not_present
+  allowed_prefixes:
+    - jobs/
+  remote:
+    endpoint: http://registry:5000
+    insecure: true

--- a/internal/api/handler/image_handler.go
+++ b/internal/api/handler/image_handler.go
@@ -4,28 +4,73 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/hoonzinope/go-job-runner/internal/image"
 )
 
-type ImageHandler struct{}
+type ImageHandler struct {
+	resolver *image.Resolver
+}
 
-func NewImageHandler() *ImageHandler {
-	return &ImageHandler{}
+func NewImageHandler(resolver *image.Resolver) *ImageHandler {
+	return &ImageHandler{resolver: resolver}
 }
 
 func (h *ImageHandler) ListImages(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{
-		"error": "image source handling is not implemented yet",
-	})
+	sourceType := c.Query("sourceType")
+	if sourceType == "" {
+		sourceType = h.resolver.DefaultSource()
+	}
+	q := c.Query("q")
+	prefix := c.Query("prefix")
+
+	candidates, err := h.resolver.ListCandidates(c.Request.Context(), sourceType, q, prefix)
+	if err != nil {
+		badRequest(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"items": candidates, "total": len(candidates)})
 }
 
 func (h *ImageHandler) ListImageCandidates(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{
-		"error": "image source handling is not implemented yet",
-	})
+	sourceType := c.Param("sourceType")
+	q := c.Query("q")
+	prefix := c.Query("prefix")
+
+	candidates, err := h.resolver.ListCandidates(c.Request.Context(), sourceType, q, prefix)
+	if err != nil {
+		badRequest(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"items": candidates, "total": len(candidates)})
 }
 
 func (h *ImageHandler) ResolveImage(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{
-		"error": "image source handling is not implemented yet",
-	})
+	sourceType := c.Query("sourceType")
+	if sourceType == "" {
+		sourceType = h.resolver.DefaultSource()
+	}
+	imageRef := c.Query("imageRef")
+	if imageRef == "" {
+		badRequest(c, errRequired("imageRef"))
+		return
+	}
+
+	candidate, err := h.resolver.Resolve(c.Request.Context(), sourceType, imageRef)
+	if err != nil {
+		badRequest(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, candidate)
+}
+
+func errRequired(field string) error {
+	return &fieldError{field: field}
+}
+
+type fieldError struct {
+	field string
+}
+
+func (e *fieldError) Error() string {
+	return e.field + " is required"
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -9,23 +9,26 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/hoonzinope/go-job-runner/internal/api/handler"
 	"github.com/hoonzinope/go-job-runner/internal/config"
+	"github.com/hoonzinope/go-job-runner/internal/image"
 	"github.com/hoonzinope/go-job-runner/internal/scheduler"
 	"github.com/hoonzinope/go-job-runner/internal/store"
 )
 
 type APIServer struct {
-	Host      string
-	Port      int
-	Store     *store.Store
-	Scheduler *scheduler.Scheduler
+	Host          string
+	Port          int
+	Store         *store.Store
+	Scheduler     *scheduler.Scheduler
+	ImageResolver *image.Resolver
 }
 
 func NewAPIServer(cfg *config.Config, st *store.Store, sch *scheduler.Scheduler) *APIServer {
 	return &APIServer{
-		Host:      cfg.Server.Host,
-		Port:      cfg.Server.Port,
-		Store:     st,
-		Scheduler: sch,
+		Host:          cfg.Server.Host,
+		Port:          cfg.Server.Port,
+		Store:         st,
+		Scheduler:     sch,
+		ImageResolver: image.NewResolver(cfg.Image),
 	}
 }
 
@@ -37,7 +40,7 @@ func (s *APIServer) setupRouter() *gin.Engine {
 	{
 		jobHandler := handler.NewJobHandler(s.Store, s.Scheduler)
 		runHandler := handler.NewRunHandler(s.Store)
-		imageHandler := handler.NewImageHandler()
+		imageHandler := handler.NewImageHandler(s.ImageResolver)
 
 		api.GET("/jobs", jobHandler.ListJobs)
 		api.GET("/jobs/:jobId", jobHandler.GetJob)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,8 +17,22 @@ type SchedulerConfig struct {
 	MaxConcurrentRuns       int `yaml:"max_concurrent_runs"`
 }
 
+type ImageRemoteConfig struct {
+	Endpoint string `yaml:"endpoint"`
+	Insecure bool   `yaml:"insecure"`
+}
+
+type ImageConfig struct {
+	AllowedSources  []string          `yaml:"allowed_sources"`
+	DefaultSource   string            `yaml:"default_source"`
+	PullPolicy      string            `yaml:"pull_policy"`
+	AllowedPrefixes []string          `yaml:"allowed_prefixes"`
+	Remote          ImageRemoteConfig `yaml:"remote"`
+}
+
 type Config struct {
 	Server    ServerConfig    `yaml:"server"`
 	Store     StoreConfig     `yaml:"store"`
 	Scheduler SchedulerConfig `yaml:"scheduler"`
+	Image     ImageConfig     `yaml:"image"`
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log"
+	"strings"
 )
 
 func (c *Config) Validate() error {
@@ -50,9 +51,42 @@ func (c *Config) Validate() error {
 		log.Printf("Image pull_policy is required")
 		return fmt.Errorf("image pull_policy is required")
 	}
-	if c.Image.Remote.Endpoint == "" {
-		log.Printf("Image remote.endpoint is required")
-		return fmt.Errorf("image remote.endpoint is required")
+
+	validSource := map[string]struct{}{
+		"local":  {},
+		"remote": {},
+	}
+	for _, source := range c.Image.AllowedSources {
+		if _, ok := validSource[source]; !ok {
+			return fmt.Errorf("unsupported image allowed_source: %q", source)
+		}
+	}
+	if _, ok := validSource[c.Image.DefaultSource]; !ok {
+		return fmt.Errorf("unsupported image default_source: %q", c.Image.DefaultSource)
+	}
+	if !containsString(c.Image.AllowedSources, c.Image.DefaultSource) {
+		return fmt.Errorf("default_source %q must be included in allowed_sources", c.Image.DefaultSource)
+	}
+	validPullPolicy := map[string]struct{}{
+		"always":         {},
+		"if_not_present": {},
+		"never":          {},
+	}
+	if _, ok := validPullPolicy[strings.ToLower(c.Image.PullPolicy)]; !ok {
+		return fmt.Errorf("unsupported image pull_policy: %q", c.Image.PullPolicy)
+	}
+	remoteEnabled := containsString(c.Image.AllowedSources, "remote") || c.Image.DefaultSource == "remote"
+	if remoteEnabled && c.Image.Remote.Endpoint == "" {
+		return fmt.Errorf("image remote.endpoint is required when remote source is enabled")
 	}
 	return nil
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -38,5 +38,21 @@ func (c *Config) Validate() error {
 		log.Printf("Scheduler max_concurrent_runs must be > 0")
 		return fmt.Errorf("scheduler max_concurrent_runs must be > 0")
 	}
+	if len(c.Image.AllowedSources) == 0 {
+		log.Printf("Image allowed_sources is required")
+		return fmt.Errorf("image allowed_sources is required")
+	}
+	if c.Image.DefaultSource == "" {
+		log.Printf("Image default_source is required")
+		return fmt.Errorf("image default_source is required")
+	}
+	if c.Image.PullPolicy == "" {
+		log.Printf("Image pull_policy is required")
+		return fmt.Errorf("image pull_policy is required")
+	}
+	if c.Image.Remote.Endpoint == "" {
+		log.Printf("Image remote.endpoint is required")
+		return fmt.Errorf("image remote.endpoint is required")
+	}
 	return nil
 }

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -56,7 +56,12 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 		return nil, err
 	}
 
-	if err := e.ensureImage(ctx, candidate.ImageRef); err != nil {
+	pullRef := candidate.PullRef
+	if pullRef == "" {
+		pullRef = candidate.ImageRef
+	}
+
+	if err := e.ensureImage(ctx, pullRef); err != nil {
 		return nil, err
 	}
 
@@ -83,7 +88,7 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	if job.TimeoutSec > 0 {
 		args = append(args, "--stop-timeout", strconv.Itoa(job.TimeoutSec))
 	}
-	args = append(args, candidate.ImageRef)
+	args = append(args, pullRef)
 
 	runCtx := ctx
 	cancelRun := func() {}
@@ -98,7 +103,7 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	if params := jobParamsJSON(job); strings.TrimSpace(params) != "" {
 		// Jobs are image-driven; params are made available as env vars for the container.
 		// The executor keeps this simple by serializing them into a single env var.
-		cmd.Env = []string{"JOB_PARAMS=" + params}
+		cmd.Env = append(os.Environ(), "JOB_PARAMS="+params)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -122,6 +127,14 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 		if err != nil {
 			exitCode := exitCodeFromErr(err)
 			if exitCode == -1 {
+				if writeErr := e.writeResult(resultPath, run, job, candidate, exitCode, err.Error()); writeErr != nil {
+					return &ExecutionResult{
+						ExitCode:    exitCode,
+						LogPath:     logPath,
+						ResultPath:  resultPath,
+						ImageDigest: candidate.Digest,
+					}, fmt.Errorf("write result: %w", writeErr)
+				}
 				return &ExecutionResult{
 					ExitCode:    exitCode,
 					LogPath:     logPath,
@@ -129,7 +142,14 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 					ImageDigest: candidate.Digest,
 				}, err
 			}
-			_ = e.writeResult(resultPath, run, job, candidate, exitCode, err.Error())
+			if writeErr := e.writeResult(resultPath, run, job, candidate, exitCode, err.Error()); writeErr != nil {
+				return &ExecutionResult{
+					ExitCode:    exitCode,
+					LogPath:     logPath,
+					ResultPath:  resultPath,
+					ImageDigest: candidate.Digest,
+				}, fmt.Errorf("write result: %w", writeErr)
+			}
 			return &ExecutionResult{
 				ExitCode:    exitCode,
 				LogPath:     logPath,
@@ -137,7 +157,14 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 				ImageDigest: candidate.Digest,
 			}, err
 		}
-		_ = e.writeResult(resultPath, run, job, candidate, 0, "success")
+		if writeErr := e.writeResult(resultPath, run, job, candidate, 0, "success"); writeErr != nil {
+			return &ExecutionResult{
+				ExitCode:    0,
+				LogPath:     logPath,
+				ResultPath:  resultPath,
+				ImageDigest: candidate.Digest,
+			}, fmt.Errorf("write result: %w", writeErr)
+		}
 		return &ExecutionResult{
 			ExitCode:    0,
 			LogPath:     logPath,
@@ -178,6 +205,7 @@ func (e *DockerExecutor) writeResult(resultPath string, run *model.Run, job *mod
 		"jobId":       job.ID,
 		"runId":       run.ID,
 		"imageRef":    candidate.ImageRef,
+		"pullRef":     candidate.PullRef,
 		"imageDigest": candidate.Digest,
 		"exitCode":    exitCode,
 		"message":     message,

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -88,16 +88,15 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	if job.TimeoutSec > 0 {
 		args = append(args, "--stop-timeout", strconv.Itoa(job.TimeoutSec))
 	}
+	if params := jobParamsJSON(job); strings.TrimSpace(params) != "" {
+		// Pass parameters into the container, not the docker CLI process.
+		args = append(args, "-e", "JOB_PARAMS="+params)
+	}
 	args = append(args, pullRef)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	if params := jobParamsJSON(job); strings.TrimSpace(params) != "" {
-		// Jobs are image-driven; params are made available as env vars for the container.
-		// The executor keeps this simple by serializing them into a single env var.
-		cmd.Env = append(os.Environ(), "JOB_PARAMS="+params)
-	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start docker run: %w", err)
@@ -115,7 +114,12 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 		cancelStop()
 		_ = cmd.Process.Kill()
 		_ = <-waitCh
-		return nil, ctx.Err()
+		return &ExecutionResult{
+			ExitCode:    -1,
+			LogPath:     logPath,
+			ResultPath:  resultPath,
+			ImageDigest: candidate.Digest,
+		}, ctx.Err()
 	case err := <-waitCh:
 		if err != nil {
 			exitCode := exitCodeFromErr(err)
@@ -175,7 +179,15 @@ func (e *DockerExecutor) ensureImage(ctx context.Context, imageRef string) error
 		}
 		fallthrough
 	case "always":
-		return exec.CommandContext(ctx, "docker", "pull", imageRef).Run()
+		out, err := exec.CommandContext(ctx, "docker", "pull", imageRef).CombinedOutput()
+		if err != nil {
+			trimmed := strings.TrimSpace(string(out))
+			if trimmed != "" {
+				return fmt.Errorf("docker pull %q: %w: %s", imageRef, err, trimmed)
+			}
+			return fmt.Errorf("docker pull %q: %w", imageRef, err)
+		}
+		return nil
 	case "never":
 		return nil
 	default:

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -83,7 +83,7 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	}
 	defer logFile.Close()
 
-	containerName := fmt.Sprintf("job-runner-run-%d-%d-%d", run.JobID, run.ID, time.Now().UTC().UnixNano())
+	containerName := fmt.Sprintf("job-runner-run-%d-%d", run.JobID, run.ID)
 	args := []string{"run", "--rm", "--name", containerName}
 	if job.TimeoutSec > 0 {
 		args = append(args, "--stop-timeout", strconv.Itoa(job.TimeoutSec))

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -90,14 +90,7 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	}
 	args = append(args, pullRef)
 
-	runCtx := ctx
-	cancelRun := func() {}
-	if job.TimeoutSec > 0 {
-		runCtx, cancelRun = context.WithTimeout(ctx, time.Duration(job.TimeoutSec)*time.Second)
-	}
-	defer cancelRun()
-
-	cmd := exec.CommandContext(runCtx, "docker", args...)
+	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	if params := jobParamsJSON(job); strings.TrimSpace(params) != "" {
@@ -116,13 +109,13 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	}()
 
 	select {
-	case <-runCtx.Done():
+	case <-ctx.Done():
 		stopCtx, cancelStop := context.WithTimeout(context.Background(), 10*time.Second)
 		_ = exec.CommandContext(stopCtx, "docker", "stop", containerName).Run()
 		cancelStop()
 		_ = cmd.Process.Kill()
 		_ = <-waitCh
-		return nil, runCtx.Err()
+		return nil, ctx.Err()
 	case err := <-waitCh:
 		if err != nil {
 			exitCode := exitCodeFromErr(err)

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -78,20 +78,27 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	}
 	defer logFile.Close()
 
-	containerName := fmt.Sprintf("job-runner-run-%d-%d", run.JobID, run.ID)
+	containerName := fmt.Sprintf("job-runner-run-%d-%d-%d", run.JobID, run.ID, time.Now().UTC().UnixNano())
 	args := []string{"run", "--rm", "--name", containerName}
 	if job.TimeoutSec > 0 {
 		args = append(args, "--stop-timeout", strconv.Itoa(job.TimeoutSec))
 	}
 	args = append(args, candidate.ImageRef)
 
-	cmd := exec.Command("docker", args...)
+	runCtx := ctx
+	cancelRun := func() {}
+	if job.TimeoutSec > 0 {
+		runCtx, cancelRun = context.WithTimeout(ctx, time.Duration(job.TimeoutSec)*time.Second)
+	}
+	defer cancelRun()
+
+	cmd := exec.CommandContext(runCtx, "docker", args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	if params := jobParamsJSON(job); strings.TrimSpace(params) != "" {
 		// Jobs are image-driven; params are made available as env vars for the container.
 		// The executor keeps this simple by serializing them into a single env var.
-		cmd.Env = append(os.Environ(), "JOB_PARAMS="+params)
+		cmd.Env = []string{"JOB_PARAMS=" + params}
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -104,11 +111,13 @@ func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model
 	}()
 
 	select {
-	case <-ctx.Done():
-		_ = exec.Command("docker", "stop", containerName).Run()
+	case <-runCtx.Done():
+		stopCtx, cancelStop := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = exec.CommandContext(stopCtx, "docker", "stop", containerName).Run()
+		cancelStop()
 		_ = cmd.Process.Kill()
 		_ = <-waitCh
-		return nil, ctx.Err()
+		return nil, runCtx.Err()
 	case err := <-waitCh:
 		if err != nil {
 			exitCode := exitCodeFromErr(err)

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -1,0 +1,200 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hoonzinope/go-job-runner/internal/config"
+	"github.com/hoonzinope/go-job-runner/internal/image"
+	"github.com/hoonzinope/go-job-runner/internal/model"
+)
+
+type ExecutionResult struct {
+	ExitCode    int
+	LogPath     string
+	ResultPath  string
+	ImageDigest *string
+}
+
+type DockerExecutor struct {
+	logRoot      string
+	artifactRoot string
+	pullPolicy   string
+	resolver     *image.Resolver
+}
+
+func NewDockerExecutor(storeCfg config.StoreConfig, imageCfg config.ImageConfig) *DockerExecutor {
+	return &DockerExecutor{
+		logRoot:      storeCfg.LogRoot,
+		artifactRoot: storeCfg.ArtifactRoot,
+		pullPolicy:   imageCfg.PullPolicy,
+		resolver:     image.NewResolver(imageCfg),
+	}
+}
+
+func (e *DockerExecutor) Execute(ctx context.Context, job *model.Job, run *model.Run) (*ExecutionResult, error) {
+	if job == nil || run == nil {
+		return nil, fmt.Errorf("job and run are required")
+	}
+	if !e.resolver.SourceAllowed(string(job.SourceType)) {
+		return nil, fmt.Errorf("source type %q is not allowed", job.SourceType)
+	}
+	if err := e.resolver.ValidateRef(job.ImageRef); err != nil {
+		return nil, err
+	}
+
+	candidate, err := e.resolver.Resolve(ctx, string(job.SourceType), job.ImageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := e.ensureImage(ctx, candidate.ImageRef); err != nil {
+		return nil, err
+	}
+
+	logPath, resultPath, err := e.preparePaths(job, run)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(resultPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create artifact dir: %w", err)
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+	defer logFile.Close()
+
+	containerName := fmt.Sprintf("job-runner-run-%d-%d", run.JobID, run.ID)
+	args := []string{"run", "--rm", "--name", containerName}
+	if job.TimeoutSec > 0 {
+		args = append(args, "--stop-timeout", strconv.Itoa(job.TimeoutSec))
+	}
+	args = append(args, candidate.ImageRef)
+
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if params := jobParamsJSON(job); strings.TrimSpace(params) != "" {
+		// Jobs are image-driven; params are made available as env vars for the container.
+		// The executor keeps this simple by serializing them into a single env var.
+		cmd.Env = append(os.Environ(), "JOB_PARAMS="+params)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start docker run: %w", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = exec.Command("docker", "stop", containerName).Run()
+		_ = cmd.Process.Kill()
+		_ = <-waitCh
+		return nil, ctx.Err()
+	case err := <-waitCh:
+		if err != nil {
+			exitCode := exitCodeFromErr(err)
+			if exitCode == -1 {
+				return &ExecutionResult{
+					ExitCode:    exitCode,
+					LogPath:     logPath,
+					ResultPath:  resultPath,
+					ImageDigest: candidate.Digest,
+				}, err
+			}
+			_ = e.writeResult(resultPath, run, job, candidate, exitCode, err.Error())
+			return &ExecutionResult{
+				ExitCode:    exitCode,
+				LogPath:     logPath,
+				ResultPath:  resultPath,
+				ImageDigest: candidate.Digest,
+			}, err
+		}
+		_ = e.writeResult(resultPath, run, job, candidate, 0, "success")
+		return &ExecutionResult{
+			ExitCode:    0,
+			LogPath:     logPath,
+			ResultPath:  resultPath,
+			ImageDigest: candidate.Digest,
+		}, nil
+	}
+}
+
+func (e *DockerExecutor) ensureImage(ctx context.Context, imageRef string) error {
+	switch strings.ToLower(strings.TrimSpace(e.pullPolicy)) {
+	case "", "if_not_present":
+		if err := exec.CommandContext(ctx, "docker", "image", "inspect", imageRef).Run(); err == nil {
+			return nil
+		}
+		fallthrough
+	case "always":
+		return exec.CommandContext(ctx, "docker", "pull", imageRef).Run()
+	case "never":
+		return nil
+	default:
+		return fmt.Errorf("unsupported pull policy %q", e.pullPolicy)
+	}
+}
+
+func (e *DockerExecutor) preparePaths(job *model.Job, run *model.Run) (string, string, error) {
+	base := filepath.Join(e.logRoot, fmt.Sprintf("job-%d", job.ID), fmt.Sprintf("run-%d", run.ID))
+	logPath := filepath.Join(base, "run.log")
+	resultPath := filepath.Join(e.artifactRoot, fmt.Sprintf("job-%d", job.ID), fmt.Sprintf("run-%d", run.ID), "result.json")
+	return logPath, resultPath, nil
+}
+
+func (e *DockerExecutor) writeResult(resultPath string, run *model.Run, job *model.Job, candidate *image.Candidate, exitCode int, message string) error {
+	if err := os.MkdirAll(filepath.Dir(resultPath), 0o755); err != nil {
+		return err
+	}
+	payload := map[string]any{
+		"jobId":       job.ID,
+		"runId":       run.ID,
+		"imageRef":    candidate.ImageRef,
+		"imageDigest": candidate.Digest,
+		"exitCode":    exitCode,
+		"message":     message,
+		"finishedAt":  time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(resultPath, data, 0o644)
+}
+
+func exitCodeFromErr(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return -1
+	}
+	return exitErr.ExitCode()
+}
+
+func jobParamsJSON(j *model.Job) string {
+	if j == nil || j.ParamsJSON == nil {
+		return ""
+	}
+	return *j.ParamsJSON
+}

--- a/internal/image/local.go
+++ b/internal/image/local.go
@@ -1,0 +1,58 @@
+package image
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type LocalSource struct{}
+
+func (s *LocalSource) ListCandidates(ctx context.Context, q, prefix string) ([]Candidate, error) {
+	cmd := exec.CommandContext(ctx, "docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}\t{{.ID}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker image ls: %w", err)
+	}
+
+	var candidates []Candidate
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		fields := strings.SplitN(scanner.Text(), "\t", 2)
+		if len(fields) != 2 {
+			continue
+		}
+		ref := strings.TrimSpace(fields[0])
+		digest := strings.TrimSpace(fields[1])
+		if ref == "<none>:<none>" || ref == "" {
+			continue
+		}
+		if prefix != "" && !strings.HasPrefix(ref, prefix) {
+			continue
+		}
+		if q != "" && !strings.Contains(ref, q) {
+			continue
+		}
+		d := digest
+		candidates = append(candidates, Candidate{SourceType: "local", ImageRef: ref, Digest: &d})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan docker images: %w", err)
+	}
+	return candidates, nil
+}
+
+func (s *LocalSource) Resolve(ctx context.Context, imageRef string) (*Candidate, error) {
+	cmd := exec.CommandContext(ctx, "docker", "image", "inspect", imageRef, "--format", "{{.Id}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker image inspect %q: %w", imageRef, err)
+	}
+	digest := strings.TrimSpace(string(out))
+	if digest == "" {
+		return &Candidate{SourceType: "local", ImageRef: imageRef}, nil
+	}
+	return &Candidate{SourceType: "local", ImageRef: imageRef, Digest: &digest}, nil
+}

--- a/internal/image/local.go
+++ b/internal/image/local.go
@@ -36,7 +36,7 @@ func (s *LocalSource) ListCandidates(ctx context.Context, q, prefix string) ([]C
 			continue
 		}
 		d := digest
-		candidates = append(candidates, Candidate{SourceType: "local", ImageRef: ref, Digest: &d})
+		candidates = append(candidates, Candidate{SourceType: "local", ImageRef: ref, PullRef: ref, Digest: &d})
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scan docker images: %w", err)
@@ -52,7 +52,7 @@ func (s *LocalSource) Resolve(ctx context.Context, imageRef string) (*Candidate,
 	}
 	digest := strings.TrimSpace(string(out))
 	if digest == "" {
-		return &Candidate{SourceType: "local", ImageRef: imageRef}, nil
+		return &Candidate{SourceType: "local", ImageRef: imageRef, PullRef: imageRef}, nil
 	}
-	return &Candidate{SourceType: "local", ImageRef: imageRef, Digest: &digest}, nil
+	return &Candidate{SourceType: "local", ImageRef: imageRef, PullRef: imageRef, Digest: &digest}, nil
 }

--- a/internal/image/remote.go
+++ b/internal/image/remote.go
@@ -1,0 +1,146 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hoonzinope/go-job-runner/internal/config"
+)
+
+type RemoteSource struct {
+	endpoint string
+	client   *http.Client
+}
+
+func NewRemoteSource(cfg config.ImageRemoteConfig) *RemoteSource {
+	return &RemoteSource{
+		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
+		client:   &http.Client{},
+	}
+}
+
+func (s *RemoteSource) ListCandidates(ctx context.Context, q, prefix string) ([]Candidate, error) {
+	repos, err := s.listRepositories(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []Candidate
+	for _, repo := range repos {
+		if prefix != "" && !strings.HasPrefix(repo, prefix) {
+			continue
+		}
+		if q != "" && !strings.Contains(repo, q) {
+			continue
+		}
+		tags, err := s.listTags(ctx, repo)
+		if err != nil {
+			continue
+		}
+		for _, tag := range tags {
+			ref := fmt.Sprintf("%s:%s", repo, tag)
+			if q != "" && !strings.Contains(ref, q) {
+				continue
+			}
+			candidates = append(candidates, Candidate{SourceType: "remote", ImageRef: ref})
+		}
+	}
+	return candidates, nil
+}
+
+func (s *RemoteSource) Resolve(ctx context.Context, imageRef string) (*Candidate, error) {
+	repo, tag := splitImageRef(imageRef)
+	if repo == "" || tag == "" {
+		return nil, fmt.Errorf("invalid remote image ref %q", imageRef)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"/v2/"+repo+"/manifests/"+url.PathEscape(tag), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("remote manifest request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("remote manifest status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		var payload map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err == nil {
+			if v, ok := payload["config"].(map[string]any); ok {
+				if d, ok := v["digest"].(string); ok {
+					digest = d
+				}
+			}
+		}
+	}
+	if digest == "" {
+		return &Candidate{SourceType: "remote", ImageRef: imageRef}, nil
+	}
+	return &Candidate{SourceType: "remote", ImageRef: imageRef, Digest: &digest}, nil
+}
+
+func (s *RemoteSource) listRepositories(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"/v2/_catalog?n=1000", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("remote catalog request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("remote catalog status %d", resp.StatusCode)
+	}
+	var payload struct {
+		Repositories []string `json:"repositories"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode remote catalog: %w", err)
+	}
+	return payload.Repositories, nil
+}
+
+func (s *RemoteSource) listTags(ctx context.Context, repo string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"/v2/"+repo+"/tags/list", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("remote tags request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("remote tags status %d", resp.StatusCode)
+	}
+	var payload struct {
+		Tags []string `json:"tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode remote tags: %w", err)
+	}
+	return payload.Tags, nil
+}
+
+func splitImageRef(ref string) (string, string) {
+	lastColon := strings.LastIndex(ref, ":")
+	lastSlash := strings.LastIndex(ref, "/")
+	if lastColon <= lastSlash || lastColon == -1 {
+		return ref, "latest"
+	}
+	return ref[:lastColon], ref[lastColon+1:]
+}

--- a/internal/image/remote.go
+++ b/internal/image/remote.go
@@ -2,7 +2,9 @@ package image
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -136,6 +138,13 @@ func (s *RemoteSource) ListCandidates(ctx context.Context, q, prefix string) ([]
 			}
 		case item, ok := <-results:
 			if !ok {
+				select {
+				case err := <-errCh:
+					if err != nil {
+						return nil, err
+					}
+				default:
+				}
 				return candidates, nil
 			}
 			candidates = append(candidates, item.items...)
@@ -176,10 +185,15 @@ func (s *RemoteSource) Resolve(ctx context.Context, imageRef string) (*Candidate
 		return nil, fmt.Errorf("remote manifest status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read remote manifest body: %w", err)
+	}
+
 	digest := resp.Header.Get("Docker-Content-Digest")
 	if digest == "" {
 		var payload map[string]any
-		if err := json.NewDecoder(resp.Body).Decode(&payload); err == nil {
+		if err := json.Unmarshal(body, &payload); err == nil {
 			if v, ok := payload["config"].(map[string]any); ok {
 				if d, ok := v["digest"].(string); ok {
 					digest = d
@@ -188,32 +202,48 @@ func (s *RemoteSource) Resolve(ctx context.Context, imageRef string) (*Candidate
 		}
 	}
 	if digest == "" {
-		return &Candidate{SourceType: "remote", ImageRef: imageRef, PullRef: pullRef}, nil
+		sum := sha256.Sum256(body)
+		digest = "sha256:" + hex.EncodeToString(sum[:])
 	}
 	return &Candidate{SourceType: "remote", ImageRef: imageRef, PullRef: pullRef, Digest: &digest}, nil
 }
 
 func (s *RemoteSource) listRepositories(ctx context.Context) ([]string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"/v2/_catalog?n=1000", nil)
-	if err != nil {
-		return nil, err
+	var repos []string
+	nextURL := s.endpoint + "/v2/_catalog?n=1000"
+
+	for nextURL != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := s.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("remote catalog request: %w", err)
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read remote catalog: %w", readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			trimmed := body
+			if len(trimmed) > 512 {
+				trimmed = trimmed[:512]
+			}
+			return nil, fmt.Errorf("remote catalog status %d: %s", resp.StatusCode, strings.TrimSpace(string(trimmed)))
+		}
+		var payload struct {
+			Repositories []string `json:"repositories"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, fmt.Errorf("decode remote catalog: %w", err)
+		}
+		repos = append(repos, payload.Repositories...)
+		nextURL = nextCatalogLink(resp.Request.URL, resp.Header.Values("Link"))
 	}
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("remote catalog request: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("remote catalog status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-	var payload struct {
-		Repositories []string `json:"repositories"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return nil, fmt.Errorf("decode remote catalog: %w", err)
-	}
-	return payload.Repositories, nil
+	return repos, nil
 }
 
 func (s *RemoteSource) listTags(ctx context.Context, repo string) ([]string, error) {
@@ -274,4 +304,29 @@ func splitImageRef(ref string) (string, string, bool) {
 		return ref, "latest", false
 	}
 	return ref[:lastColon], ref[lastColon+1:], false
+}
+
+func nextCatalogLink(base *url.URL, values []string) string {
+	for _, value := range values {
+		parts := strings.Split(value, ",")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if !strings.Contains(part, `rel="next"`) {
+				continue
+			}
+			start := strings.Index(part, "<")
+			end := strings.Index(part, ">")
+			if start >= 0 && end > start+1 {
+				next, err := url.Parse(part[start+1 : end])
+				if err != nil {
+					return ""
+				}
+				if base != nil {
+					return base.ResolveReference(next).String()
+				}
+				return next.String()
+			}
+		}
+	}
+	return ""
 }

--- a/internal/image/remote.go
+++ b/internal/image/remote.go
@@ -31,6 +31,8 @@ type tagCacheEntry struct {
 	fetchedAt time.Time
 }
 
+const maxConcurrentTagFetches = 8
+
 func NewRemoteSource(cfg config.ImageRemoteConfig) *RemoteSource {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if cfg.Insecure {
@@ -79,8 +81,8 @@ func (s *RemoteSource) ListCandidates(ctx context.Context, q, prefix string) ([]
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	sem := make(chan struct{}, 8)
-	results := make(chan repoTags, len(filteredRepos))
+	sem := make(chan struct{}, maxConcurrentTagFetches)
+	results := make(chan repoTags, 64)
 	errCh := make(chan error, 1)
 	var wg sync.WaitGroup
 

--- a/internal/image/remote.go
+++ b/internal/image/remote.go
@@ -42,9 +42,12 @@ func NewRemoteSource(cfg config.ImageRemoteConfig) *RemoteSource {
 	return &RemoteSource{
 		endpoint:   strings.TrimRight(cfg.Endpoint, "/"),
 		pullPrefix: pullPrefix,
-		client:     &http.Client{Transport: transport},
-		tagCache:   make(map[string]tagCacheEntry),
-		cacheTTL:   5 * time.Minute,
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   30 * time.Second,
+		},
+		tagCache: make(map[string]tagCacheEntry),
+		cacheTTL: 5 * time.Minute,
 	}
 }
 
@@ -146,13 +149,18 @@ func (s *RemoteSource) ListCandidates(ctx context.Context, q, prefix string) ([]
 }
 
 func (s *RemoteSource) Resolve(ctx context.Context, imageRef string) (*Candidate, error) {
-	repo, tag := splitImageRef(imageRef)
-	if repo == "" || tag == "" {
+	repo, ref, isDigest := splitImageRef(imageRef)
+	if repo == "" || ref == "" {
 		return nil, fmt.Errorf("invalid remote image ref %q", imageRef)
 	}
-	pullRef := fmt.Sprintf("%s/%s:%s", s.pullPrefix, repo, tag)
+	var pullRef string
+	if isDigest {
+		pullRef = fmt.Sprintf("%s/%s@%s", s.pullPrefix, repo, ref)
+	} else {
+		pullRef = fmt.Sprintf("%s/%s:%s", s.pullPrefix, repo, ref)
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"/v2/"+repo+"/manifests/"+url.PathEscape(tag), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"/v2/"+repo+"/manifests/"+url.PathEscape(ref), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -256,11 +264,14 @@ func (s *RemoteSource) tagsForRepo(ctx context.Context, repo string) ([]string, 
 	return tags, nil
 }
 
-func splitImageRef(ref string) (string, string) {
+func splitImageRef(ref string) (string, string, bool) {
+	if repo, digest, ok := strings.Cut(ref, "@"); ok {
+		return repo, digest, true
+	}
 	lastColon := strings.LastIndex(ref, ":")
 	lastSlash := strings.LastIndex(ref, "/")
 	if lastColon <= lastSlash || lastColon == -1 {
-		return ref, "latest"
+		return ref, "latest", false
 	}
-	return ref[:lastColon], ref[lastColon+1:]
+	return ref[:lastColon], ref[lastColon+1:], false
 }

--- a/internal/image/remote.go
+++ b/internal/image/remote.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,9 +19,13 @@ type RemoteSource struct {
 }
 
 func NewRemoteSource(cfg config.ImageRemoteConfig) *RemoteSource {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if cfg.Insecure {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint:gosec
+	}
 	return &RemoteSource{
 		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
-		client:   &http.Client{},
+		client:   &http.Client{Transport: transport},
 	}
 }
 
@@ -40,7 +45,7 @@ func (s *RemoteSource) ListCandidates(ctx context.Context, q, prefix string) ([]
 		}
 		tags, err := s.listTags(ctx, repo)
 		if err != nil {
-			continue
+			return nil, err
 		}
 		for _, tag := range tags {
 			ref := fmt.Sprintf("%s:%s", repo, tag)
@@ -103,7 +108,8 @@ func (s *RemoteSource) listRepositories(ctx context.Context) ([]string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("remote catalog status %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("remote catalog status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var payload struct {
 		Repositories []string `json:"repositories"`
@@ -125,7 +131,8 @@ func (s *RemoteSource) listTags(ctx context.Context, repo string) ([]string, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("remote tags status %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("remote tags status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var payload struct {
 		Tags []string `json:"tags"`

--- a/internal/image/remote.go
+++ b/internal/image/remote.go
@@ -16,11 +16,12 @@ import (
 )
 
 type RemoteSource struct {
-	endpoint string
-	client   *http.Client
-	cacheMu  sync.RWMutex
-	tagCache map[string]tagCacheEntry
-	cacheTTL time.Duration
+	endpoint   string
+	pullPrefix string
+	client     *http.Client
+	cacheMu    sync.RWMutex
+	tagCache   map[string]tagCacheEntry
+	cacheTTL   time.Duration
 }
 
 type tagCacheEntry struct {
@@ -33,11 +34,17 @@ func NewRemoteSource(cfg config.ImageRemoteConfig) *RemoteSource {
 	if cfg.Insecure {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint:gosec
 	}
+	parsed, err := url.Parse(strings.TrimRight(cfg.Endpoint, "/"))
+	pullPrefix := strings.TrimRight(cfg.Endpoint, "/")
+	if err == nil && parsed.Host != "" {
+		pullPrefix = parsed.Host
+	}
 	return &RemoteSource{
-		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
-		client:   &http.Client{Transport: transport},
-		tagCache: make(map[string]tagCacheEntry),
-		cacheTTL: 5 * time.Minute,
+		endpoint:   strings.TrimRight(cfg.Endpoint, "/"),
+		pullPrefix: pullPrefix,
+		client:     &http.Client{Transport: transport},
+		tagCache:   make(map[string]tagCacheEntry),
+		cacheTTL:   5 * time.Minute,
 	}
 }
 
@@ -143,6 +150,7 @@ func (s *RemoteSource) Resolve(ctx context.Context, imageRef string) (*Candidate
 	if repo == "" || tag == "" {
 		return nil, fmt.Errorf("invalid remote image ref %q", imageRef)
 	}
+	pullRef := fmt.Sprintf("%s/%s:%s", s.pullPrefix, repo, tag)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"/v2/"+repo+"/manifests/"+url.PathEscape(tag), nil)
 	if err != nil {
@@ -172,9 +180,9 @@ func (s *RemoteSource) Resolve(ctx context.Context, imageRef string) (*Candidate
 		}
 	}
 	if digest == "" {
-		return &Candidate{SourceType: "remote", ImageRef: imageRef}, nil
+		return &Candidate{SourceType: "remote", ImageRef: imageRef, PullRef: pullRef}, nil
 	}
-	return &Candidate{SourceType: "remote", ImageRef: imageRef, Digest: &digest}, nil
+	return &Candidate{SourceType: "remote", ImageRef: imageRef, PullRef: pullRef, Digest: &digest}, nil
 }
 
 func (s *RemoteSource) listRepositories(ctx context.Context) ([]string, error) {

--- a/internal/image/remote.go
+++ b/internal/image/remote.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/hoonzinope/go-job-runner/internal/config"
 )
@@ -16,6 +18,14 @@ import (
 type RemoteSource struct {
 	endpoint string
 	client   *http.Client
+	cacheMu  sync.RWMutex
+	tagCache map[string]tagCacheEntry
+	cacheTTL time.Duration
+}
+
+type tagCacheEntry struct {
+	tags      []string
+	fetchedAt time.Time
 }
 
 func NewRemoteSource(cfg config.ImageRemoteConfig) *RemoteSource {
@@ -26,6 +36,8 @@ func NewRemoteSource(cfg config.ImageRemoteConfig) *RemoteSource {
 	return &RemoteSource{
 		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
 		client:   &http.Client{Transport: transport},
+		tagCache: make(map[string]tagCacheEntry),
+		cacheTTL: 5 * time.Minute,
 	}
 }
 
@@ -35,7 +47,7 @@ func (s *RemoteSource) ListCandidates(ctx context.Context, q, prefix string) ([]
 		return nil, err
 	}
 
-	var candidates []Candidate
+	filteredRepos := make([]string, 0, len(repos))
 	for _, repo := range repos {
 		if prefix != "" && !strings.HasPrefix(repo, prefix) {
 			continue
@@ -43,19 +55,87 @@ func (s *RemoteSource) ListCandidates(ctx context.Context, q, prefix string) ([]
 		if q != "" && !strings.Contains(repo, q) {
 			continue
 		}
-		tags, err := s.listTags(ctx, repo)
-		if err != nil {
-			return nil, err
-		}
-		for _, tag := range tags {
-			ref := fmt.Sprintf("%s:%s", repo, tag)
-			if q != "" && !strings.Contains(ref, q) {
-				continue
+		filteredRepos = append(filteredRepos, repo)
+	}
+
+	var candidates []Candidate
+
+	type repoTags struct {
+		items []Candidate
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sem := make(chan struct{}, 8)
+	results := make(chan repoTags, len(filteredRepos))
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	for _, repo := range filteredRepos {
+		repo := repo
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
 			}
-			candidates = append(candidates, Candidate{SourceType: "remote", ImageRef: ref})
+			defer func() { <-sem }()
+
+			tags, err := s.tagsForRepo(ctx, repo)
+			if err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				cancel()
+				return
+			}
+			items := make([]Candidate, 0, len(tags))
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			for _, tag := range tags {
+				ref := fmt.Sprintf("%s:%s", repo, tag)
+				if q != "" && !strings.Contains(ref, q) {
+					continue
+				}
+				items = append(items, Candidate{SourceType: "remote", ImageRef: ref})
+			}
+			select {
+			case results <- repoTags{items: items}:
+			case <-ctx.Done():
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				return nil, err
+			}
+		case item, ok := <-results:
+			if !ok {
+				return candidates, nil
+			}
+			candidates = append(candidates, item.items...)
+		case <-ctx.Done():
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return candidates, nil
 		}
 	}
-	return candidates, nil
 }
 
 func (s *RemoteSource) Resolve(ctx context.Context, imageRef string) (*Candidate, error) {
@@ -141,6 +221,31 @@ func (s *RemoteSource) listTags(ctx context.Context, repo string) ([]string, err
 		return nil, fmt.Errorf("decode remote tags: %w", err)
 	}
 	return payload.Tags, nil
+}
+
+func (s *RemoteSource) tagsForRepo(ctx context.Context, repo string) ([]string, error) {
+	now := time.Now().UTC()
+
+	s.cacheMu.RLock()
+	if entry, ok := s.tagCache[repo]; ok && now.Sub(entry.fetchedAt) < s.cacheTTL {
+		tags := append([]string(nil), entry.tags...)
+		s.cacheMu.RUnlock()
+		return tags, nil
+	}
+	s.cacheMu.RUnlock()
+
+	tags, err := s.listTags(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cacheMu.Lock()
+	s.tagCache[repo] = tagCacheEntry{
+		tags:      append([]string(nil), tags...),
+		fetchedAt: now,
+	}
+	s.cacheMu.Unlock()
+	return tags, nil
 }
 
 func splitImageRef(ref string) (string, string) {

--- a/internal/image/source.go
+++ b/internal/image/source.go
@@ -71,14 +71,14 @@ func (r *Resolver) ListCandidates(ctx context.Context, sourceType, q, prefix str
 	if !r.SourceAllowed(sourceType) {
 		return nil, fmt.Errorf("source type %q is not allowed", sourceType)
 	}
-	if prefix == "" {
-		prefix = ""
+	if err := r.ValidatePrefix(prefix); err != nil {
+		return nil, err
 	}
 	switch sourceType {
 	case "local":
-		return r.local.ListCandidates(ctx, q, prefix)
+		return r.filterCandidates(r.local.ListCandidates(ctx, q, prefix))
 	case "remote":
-		return r.remote.ListCandidates(ctx, q, prefix)
+		return r.filterCandidates(r.remote.ListCandidates(ctx, q, prefix))
 	default:
 		return nil, fmt.Errorf("unsupported source type %q", sourceType)
 	}
@@ -99,4 +99,35 @@ func (r *Resolver) Resolve(ctx context.Context, sourceType, imageRef string) (*C
 	default:
 		return nil, fmt.Errorf("unsupported source type %q", sourceType)
 	}
+}
+
+func (r *Resolver) ValidatePrefix(prefix string) error {
+	if prefix == "" || len(r.cfg.AllowedPrefixes) == 0 {
+		return nil
+	}
+	for _, allowed := range r.cfg.AllowedPrefixes {
+		if strings.HasPrefix(prefix, allowed) {
+			return nil
+		}
+	}
+	return fmt.Errorf("prefix %q is not allowed by prefix policy", prefix)
+}
+
+func (r *Resolver) filterCandidates(candidates []Candidate, err error) ([]Candidate, error) {
+	if err != nil {
+		return nil, err
+	}
+	if len(r.cfg.AllowedPrefixes) == 0 {
+		return candidates, nil
+	}
+	filtered := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		for _, allowed := range r.cfg.AllowedPrefixes {
+			if strings.HasPrefix(candidate.ImageRef, allowed) {
+				filtered = append(filtered, candidate)
+				break
+			}
+		}
+	}
+	return filtered, nil
 }

--- a/internal/image/source.go
+++ b/internal/image/source.go
@@ -1,0 +1,102 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hoonzinope/go-job-runner/internal/config"
+)
+
+type Candidate struct {
+	SourceType string  `json:"sourceType"`
+	ImageRef   string  `json:"imageRef"`
+	Digest     *string `json:"digest,omitempty"`
+}
+
+type Source interface {
+	ListCandidates(ctx context.Context, q, prefix string) ([]Candidate, error)
+	Resolve(ctx context.Context, imageRef string) (*Candidate, error)
+}
+
+type Resolver struct {
+	local  Source
+	remote Source
+	cfg    config.ImageConfig
+}
+
+func NewResolver(cfg config.ImageConfig) *Resolver {
+	return &Resolver{
+		local:  &LocalSource{},
+		remote: NewRemoteSource(cfg.Remote),
+		cfg:    cfg,
+	}
+}
+
+func (r *Resolver) SourceAllowed(sourceType string) bool {
+	for _, allowed := range r.cfg.AllowedSources {
+		if allowed == sourceType {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Resolver) DefaultSource() string {
+	if r.cfg.DefaultSource != "" {
+		return r.cfg.DefaultSource
+	}
+	if len(r.cfg.AllowedSources) > 0 {
+		return r.cfg.AllowedSources[0]
+	}
+	return "local"
+}
+
+func (r *Resolver) ValidateRef(imageRef string) error {
+	if imageRef == "" {
+		return fmt.Errorf("image ref is required")
+	}
+	if len(r.cfg.AllowedPrefixes) == 0 {
+		return nil
+	}
+	for _, prefix := range r.cfg.AllowedPrefixes {
+		if strings.HasPrefix(imageRef, prefix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("image ref %q is not allowed by prefix policy", imageRef)
+}
+
+func (r *Resolver) ListCandidates(ctx context.Context, sourceType, q, prefix string) ([]Candidate, error) {
+	if !r.SourceAllowed(sourceType) {
+		return nil, fmt.Errorf("source type %q is not allowed", sourceType)
+	}
+	if prefix == "" {
+		prefix = ""
+	}
+	switch sourceType {
+	case "local":
+		return r.local.ListCandidates(ctx, q, prefix)
+	case "remote":
+		return r.remote.ListCandidates(ctx, q, prefix)
+	default:
+		return nil, fmt.Errorf("unsupported source type %q", sourceType)
+	}
+}
+
+func (r *Resolver) Resolve(ctx context.Context, sourceType, imageRef string) (*Candidate, error) {
+	if err := r.ValidateRef(imageRef); err != nil {
+		return nil, err
+	}
+	if !r.SourceAllowed(sourceType) {
+		return nil, fmt.Errorf("source type %q is not allowed", sourceType)
+	}
+	switch sourceType {
+	case "local":
+		return r.local.Resolve(ctx, imageRef)
+	case "remote":
+		return r.remote.Resolve(ctx, imageRef)
+	default:
+		return nil, fmt.Errorf("unsupported source type %q", sourceType)
+	}
+}

--- a/internal/image/source.go
+++ b/internal/image/source.go
@@ -11,6 +11,7 @@ import (
 type Candidate struct {
 	SourceType string  `json:"sourceType"`
 	ImageRef   string  `json:"imageRef"`
+	PullRef    string  `json:"pullRef,omitempty"`
 	Digest     *string `json:"digest,omitempty"`
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -7,17 +7,21 @@ import (
 	"time"
 
 	"github.com/hoonzinope/go-job-runner/internal/config"
+	"github.com/hoonzinope/go-job-runner/internal/executor"
+	"github.com/hoonzinope/go-job-runner/internal/model"
 	"github.com/hoonzinope/go-job-runner/internal/store"
 )
 
 type Executor interface {
-	Execute(ctx context.Context, jobID int64, runID int64) error
+	Execute(ctx context.Context, job *model.Job, run *model.Run) (*executor.ExecutionResult, error)
 }
 
 type noopExecutor struct{}
 
-func (noopExecutor) Execute(ctx context.Context, jobID int64, runID int64) error {
-	return nil
+func (noopExecutor) Execute(ctx context.Context, job *model.Job, run *model.Run) (*executor.ExecutionResult, error) {
+	return &executor.ExecutionResult{
+		ExitCode: 0,
+	}, nil
 }
 
 type Scheduler struct {
@@ -44,7 +48,7 @@ func NewScheduler(cfg *config.Config, st *store.Store) *Scheduler {
 		dueWakeup:         make(chan struct{}, 1),
 		dispatchWakeup:    make(chan struct{}, 1),
 		workerTokens:      make(chan struct{}, cfg.Scheduler.MaxConcurrentRuns),
-		executor:          noopExecutor{},
+		executor:          executor.NewDockerExecutor(cfg.Store, cfg.Image),
 	}
 }
 

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -70,7 +71,7 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 	if ctx.Err() != nil {
 		finishedAt := time.Now().UTC()
 		msg := "context cancelled"
-		_ = s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
+		if err := s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
 			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusCancelled, run.StartedAt, &finishedAt, run.ExitCode, run.ErrorMessage); err != nil {
 				return err
 			}
@@ -80,12 +81,21 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 				Message:   &msg,
 			})
 			return err
-		})
+		}); err != nil {
+			fmt.Printf("scheduler worker cancel finalize error (run=%d): %v\n", runID, err)
+		}
 		s.signalDispatch()
 		return
 	}
 
-	result, execErr := s.newExecutor().Execute(ctx, job, run)
+	runCtx := ctx
+	cancelRun := func() {}
+	if job.TimeoutSec > 0 {
+		runCtx, cancelRun = context.WithTimeout(ctx, time.Duration(job.TimeoutSec)*time.Second)
+	}
+	defer cancelRun()
+
+	result, execErr := s.newExecutor().Execute(runCtx, job, run)
 	finishedAt := time.Now().UTC()
 
 	if result != nil && result.LogPath != "" {
@@ -98,9 +108,15 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 		job.ImageDigest = result.ImageDigest
 	}
 
-	_ = s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
+	if err := s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
 		if result != nil {
 			if err := tx.Runs.UpdateLogArtifacts(context.Background(), runID, run.LogPath, run.ResultPath); err != nil {
+				return err
+			}
+		}
+		if result != nil && result.ImageDigest != nil {
+			job.ImageDigest = result.ImageDigest
+			if err := tx.Jobs.Update(context.Background(), job); err != nil {
 				return err
 			}
 		}
@@ -118,7 +134,22 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 				Message:   &msg,
 			})
 			return err
-		case ctx.Err() != nil:
+		case errors.Is(runCtx.Err(), context.DeadlineExceeded):
+			exitCode := -1
+			msg := "job timeout"
+			if result != nil {
+				exitCode = result.ExitCode
+			}
+			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusTimeout, run.StartedAt, &finishedAt, &exitCode, &msg); err != nil {
+				return err
+			}
+			_, err := tx.Events.Create(context.Background(), &model.RunEvent{
+				RunID:     runID,
+				EventType: model.RunEventTypeTimeout,
+				Message:   &msg,
+			})
+			return err
+		case errors.Is(runCtx.Err(), context.Canceled):
 			msg := "context cancelled"
 			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusCancelled, run.StartedAt, &finishedAt, nil, &msg); err != nil {
 				return err
@@ -135,32 +166,19 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 				exitCode = result.ExitCode
 			}
 			msg := execErr.Error()
-			status := model.RunStatusFailed
-			if isTimeoutError(execErr) {
-				status = model.RunStatusTimeout
-			}
-			if err := tx.Runs.UpdateStatus(context.Background(), runID, status, run.StartedAt, &finishedAt, &exitCode, &msg); err != nil {
+			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusFailed, run.StartedAt, &finishedAt, &exitCode, &msg); err != nil {
 				return err
-			}
-			eventType := model.RunEventTypeFailed
-			if status == model.RunStatusTimeout {
-				eventType = model.RunEventTypeTimeout
 			}
 			_, err := tx.Events.Create(context.Background(), &model.RunEvent{
 				RunID:     runID,
-				EventType: eventType,
+				EventType: model.RunEventTypeFailed,
 				Message:   &msg,
 			})
 			return err
 		}
-	})
+	}); err != nil {
+		fmt.Printf("scheduler worker finalize error (run=%d): %v\n", runID, err)
+	}
 
 	s.signalDispatch()
-}
-
-func isTimeoutError(err error) bool {
-	if err == nil {
-		return false
-	}
-	return err == context.DeadlineExceeded
 }

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -104,19 +104,10 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 	if result != nil && result.ResultPath != "" {
 		run.ResultPath = &result.ResultPath
 	}
-	if result != nil && result.ImageDigest != nil {
-		job.ImageDigest = result.ImageDigest
-	}
 
 	if err := s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
 		if result != nil {
 			if err := tx.Runs.UpdateLogArtifacts(context.Background(), runID, run.LogPath, run.ResultPath); err != nil {
-				return err
-			}
-		}
-		if result != nil && result.ImageDigest != nil {
-			job.ImageDigest = result.ImageDigest
-			if err := tx.Jobs.Update(context.Background(), job); err != nil {
 				return err
 			}
 		}

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -22,6 +22,7 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 		return
 	}
 
+	startedAt := time.Now().UTC()
 	if err := s.store.WithinTx(ctx, func(tx *store.TxStore) error {
 		freshRun, err := tx.Runs.Get(ctx, runID)
 		if err != nil {
@@ -44,7 +45,6 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 			})
 			return err
 		case model.RunStatusPending:
-			startedAt := time.Now().UTC()
 			run.StartedAt = &startedAt
 			if err := tx.Runs.UpdateStatus(ctx, runID, model.RunStatusRunning, &startedAt, nil, nil, nil); err != nil {
 				return err
@@ -57,6 +57,7 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 			})
 			return err
 		case model.RunStatusRunning:
+			run.StartedAt = freshRun.StartedAt
 			return nil
 		default:
 			return nil
@@ -67,9 +68,9 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 	}
 
 	if ctx.Err() != nil {
+		finishedAt := time.Now().UTC()
+		msg := "context cancelled"
 		_ = s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
-			finishedAt := time.Now().UTC()
-			msg := "context cancelled"
 			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusCancelled, run.StartedAt, &finishedAt, run.ExitCode, run.ErrorMessage); err != nil {
 				return err
 			}
@@ -84,37 +85,82 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 		return
 	}
 
-	if err := s.newExecutor().Execute(ctx, job.ID, run.ID); err != nil {
-		finishedAt := time.Now().UTC()
-		msg := err.Error()
-		_ = s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
-			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusFailed, run.StartedAt, &finishedAt, nil, &msg); err != nil {
+	result, execErr := s.newExecutor().Execute(ctx, job, run)
+	finishedAt := time.Now().UTC()
+
+	if result != nil && result.LogPath != "" {
+		run.LogPath = &result.LogPath
+	}
+	if result != nil && result.ResultPath != "" {
+		run.ResultPath = &result.ResultPath
+	}
+	if result != nil && result.ImageDigest != nil {
+		job.ImageDigest = result.ImageDigest
+	}
+
+	_ = s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
+		if result != nil {
+			if err := tx.Runs.UpdateLogArtifacts(context.Background(), runID, run.LogPath, run.ResultPath); err != nil {
+				return err
+			}
+		}
+
+		switch {
+		case execErr == nil:
+			exitCode := 0
+			msg := "run completed"
+			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusSuccess, run.StartedAt, &finishedAt, &exitCode, nil); err != nil {
 				return err
 			}
 			_, err := tx.Events.Create(context.Background(), &model.RunEvent{
 				RunID:     runID,
-				EventType: model.RunEventTypeFailed,
+				EventType: model.RunEventTypeCompleted,
 				Message:   &msg,
 			})
 			return err
-		})
-		s.signalDispatch()
-		return
-	}
-
-	finishedAt := time.Now().UTC()
-	exitCode := 0
-	msg := "run completed"
-	_ = s.store.WithinTx(context.Background(), func(tx *store.TxStore) error {
-		if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusSuccess, run.StartedAt, &finishedAt, &exitCode, nil); err != nil {
+		case ctx.Err() != nil:
+			msg := "context cancelled"
+			if err := tx.Runs.UpdateStatus(context.Background(), runID, model.RunStatusCancelled, run.StartedAt, &finishedAt, nil, &msg); err != nil {
+				return err
+			}
+			_, err := tx.Events.Create(context.Background(), &model.RunEvent{
+				RunID:     runID,
+				EventType: model.RunEventTypeCancelled,
+				Message:   &msg,
+			})
+			return err
+		default:
+			exitCode := -1
+			if result != nil {
+				exitCode = result.ExitCode
+			}
+			msg := execErr.Error()
+			status := model.RunStatusFailed
+			if isTimeoutError(execErr) {
+				status = model.RunStatusTimeout
+			}
+			if err := tx.Runs.UpdateStatus(context.Background(), runID, status, run.StartedAt, &finishedAt, &exitCode, &msg); err != nil {
+				return err
+			}
+			eventType := model.RunEventTypeFailed
+			if status == model.RunStatusTimeout {
+				eventType = model.RunEventTypeTimeout
+			}
+			_, err := tx.Events.Create(context.Background(), &model.RunEvent{
+				RunID:     runID,
+				EventType: eventType,
+				Message:   &msg,
+			})
 			return err
 		}
-		_, err := tx.Events.Create(context.Background(), &model.RunEvent{
-			RunID:     runID,
-			EventType: model.RunEventTypeCompleted,
-			Message:   &msg,
-		})
-		return err
 	})
+
 	s.signalDispatch()
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return err == context.DeadlineExceeded
 }

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hoonzinope/go-job-runner/internal/model"
@@ -64,7 +65,7 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 			return nil
 		}
 	}); err != nil {
-		fmt.Printf("scheduler worker start error (run=%d): %v\n", runID, err)
+		log.Printf("scheduler worker start error (run=%d): %v", runID, err)
 		return
 	}
 
@@ -82,7 +83,7 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 			})
 			return err
 		}); err != nil {
-			fmt.Printf("scheduler worker cancel finalize error (run=%d): %v\n", runID, err)
+			log.Printf("scheduler worker cancel finalize error (run=%d): %v", runID, err)
 		}
 		s.signalDispatch()
 		return
@@ -168,7 +169,7 @@ func (s *Scheduler) runWorker(ctx context.Context, runID int64) {
 			return err
 		}
 	}); err != nil {
-		fmt.Printf("scheduler worker finalize error (run=%d): %v\n", runID, err)
+		log.Printf("scheduler worker finalize error (run=%d): %v", runID, err)
 	}
 
 	s.signalDispatch()


### PR DESCRIPTION
This pull request introduces a comprehensive image management and execution system for the job runner, enabling jobs to use container images from both local and remote sources. It adds configuration and validation for image sources, implements image resolution and candidate listing, and integrates a Docker-based executor into the scheduler. This makes the platform more flexible and robust for running container-based jobs.

**Image source configuration and validation:**

* Added new `image` configuration section in `config.yml` and corresponding `ImageConfig` structs, supporting allowed sources, pull policy, allowed prefixes, and remote registry settings. Validation ensures all required image configuration fields are present. [[1]](diffhunk://#diff-5a7db8dbadaef1b1b5a8738ba70b5ffac82b8e243732154165911284e08aad4bR9-R20) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR20-R37) [[3]](diffhunk://#diff-9abd7a0266df367fa6ee3ecb0c4b3d5046d678313073c1e152e305f267ec2825R41-R56)

**Image resolution and listing implementation:**

* Introduced the `image.Resolver` abstraction, with pluggable `Source` implementations for both local Docker images and remote registries, supporting listing and resolving image references with prefix and query filtering. [[1]](diffhunk://#diff-57f641fd34ad0042270204999fcc8c82ff59fdb60551ea50060d13656e30a400R1-R102) [[2]](diffhunk://#diff-02cb81d787cfdb855b916e86b1ff851a81d1712d12f3d7f9d5d304e270212e77R1-R58) [[3]](diffhunk://#diff-f805945886fae460a13e3a53471afcc7e35d9ad6ba2adbcf05d0f1bcea40c580R1-R146)

**API enhancements for image operations:**

* Updated the API handler and router to support image listing and resolution endpoints, using the new resolver and returning appropriate results or errors. [[1]](diffhunk://#diff-48c99babaabc6ae803eb5ccf07e04e7132104b97dda1ef73a4a1fabda732a733R7-R75) [[2]](diffhunk://#diff-d6605b19340f42c0e80ddbc341238970e4996bf5ad100cba281f231f63276e9eR12) [[3]](diffhunk://#diff-d6605b19340f42c0e80ddbc341238970e4996bf5ad100cba281f231f63276e9eR22) [[4]](diffhunk://#diff-d6605b19340f42c0e80ddbc341238970e4996bf5ad100cba281f231f63276e9eR31) [[5]](diffhunk://#diff-d6605b19340f42c0e80ddbc341238970e4996bf5ad100cba281f231f63276e9eL40-R43)

**Job execution using Docker containers:**

* Added a `DockerExecutor` that pulls images (according to policy), runs jobs in containers, manages logs and result artifacts, and records execution results, integrating it as the default executor in the scheduler. [[1]](diffhunk://#diff-82e6b6d55a53ad22a77c082801eeb5939106c6f270811b4f7b26149d52d70a09R1-R200) [[2]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0R10-R24) [[3]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0L47-R51)

**Scheduler and worker integration:**

* Modified scheduler and worker logic to use the new executor interface and pass job/run objects, ensuring correct job lifecycle and result tracking. [[1]](diffhunk://#diff-eb5b31a614a6155b26060a73635199533e870d1f40f7b62c6ef18240e9e5b826R25) [[2]](diffhunk://#diff-eb5b31a614a6155b26060a73635199533e870d1f40f7b62c6ef18240e9e5b826L47)